### PR TITLE
Enable devtools in production, for easier accessibility

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,9 @@
 <script>
 import AppNavigation from '~/components/AppNavigation.vue'
 import AppFooter from '~/components/AppFooter.vue'
+import Vue from 'vue'
+
+Vue.config.devtools = true
 
 export default {
   components: {


### PR DESCRIPTION
I think it's a nice addition, to have devtools enabled. That way, everyone could play around with the app without downloading it locally.
It is not a real production app, so there is no issue there. ;)