### PR TITLE
fix broken menu

### DIFF
--- a/components/AppMenuDrawer.vue
+++ b/components/AppMenuDrawer.vue
@@ -30,9 +30,6 @@ export default {
         scale: 0,
         transformOrigin: '100% 0%'
       })
-      TweenMax.set(el.childNodes, {
-        opacity: 0
-      })
     },
     enter(el, done) {
       TweenMax.fromTo(


### PR DESCRIPTION
The menu was broken for me locally on Chrome and Firefox. Apparently TweenMax gets some text dom nodes which it doesn't like. Removing these three lines made it work just like the online demo.